### PR TITLE
Issue #7: 写真複数選択機能の実装

### DIFF
--- a/MediaLibrary/Sources/Presentation/Resources/Localizable.xcstrings
+++ b/MediaLibrary/Sources/Presentation/Resources/Localizable.xcstrings
@@ -188,6 +188,40 @@
         }
       }
     },
+    "Select" : {
+      "comment" : "Select button text for entering selection mode",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Select"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選択"
+          }
+        }
+      }
+    },
+    "Done" : {
+      "comment" : "Done button text for exiting selection mode",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Done"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "完了"
+          }
+        }
+      }
+    },
     "Thumbnail generation failed" : {
       "comment" : "Error message for thumbnail generation failure",
       "localizations" : {

--- a/MediaLibrary/Sources/Presentation/ViewModels/MediaLibraryViewModel.swift
+++ b/MediaLibrary/Sources/Presentation/ViewModels/MediaLibraryViewModel.swift
@@ -14,6 +14,8 @@ class MediaLibraryViewModel: ObservableObject {
     @Published private(set) var error: MediaError?
     @Published private(set) var permissionStatus: PhotoLibraryPermissionStatus = .notDetermined
     @Published private(set) var thumbnails: [Media.ID: Media.Thumbnail] = [:]
+    @Published private(set) var isSelectionMode = false
+    @Published var selectedMediaIDs: Set<Media.ID>? = nil
 
     // MARK: - Private Properties
 
@@ -91,6 +93,18 @@ class MediaLibraryViewModel: ObservableObject {
     /// エラーをクリアする
     func clearError() {
         error = nil
+    }
+    
+    /// 選択モードの切り替え
+    func toggleSelectionMode() {
+        isSelectionMode.toggle()
+        if isSelectionMode {
+            // 選択モードに入る時は空のSetを作成
+            selectedMediaIDs = Set<Media.ID>()
+        } else {
+            // 選択モードを終了する時はnilに
+            selectedMediaIDs = nil
+        }
     }
 
     /// すべてのサムネイル読み込みタスクをキャンセルする

--- a/MediaLibrary/Sources/Presentation/Views/GridView.swift
+++ b/MediaLibrary/Sources/Presentation/Views/GridView.swift
@@ -1,0 +1,370 @@
+import SwiftUI
+import UIKit
+
+/// 汎用的なグリッドビュー
+/// UICollectionViewをSwiftUIで使用するためのラッパー
+public struct GridView<Item: Identifiable, Content: View>: UIViewRepresentable {
+    // MARK: - Properties
+    
+    /// 表示するアイテム
+    public let items: [Item]
+    
+    /// グリッドの列数
+    public let columns: Int
+    
+    /// セル間のスペーシング
+    public let spacing: CGFloat
+    
+    /// 選択されているアイテムのID（nilの場合は選択不可）
+    @Binding public var selectedIDs: Set<Item.ID>?
+    
+    /// 各アイテムのコンテンツを生成するクロージャ
+    public let content: (Item, Bool) -> Content
+    
+    /// アイテムが表示された時のコールバック
+    public let onItemAppear: ((Item) -> Void)?
+    
+    /// アイテムがタップされた時のコールバック
+    public let onItemTap: ((Item) -> Void)?
+    
+    // MARK: - Initialization
+    
+    public init(
+        items: [Item],
+        columns: Int,
+        spacing: CGFloat = 2,
+        selectedIDs: Binding<Set<Item.ID>?>,
+        @ViewBuilder content: @escaping (Item, Bool) -> Content,
+        onItemAppear: ((Item) -> Void)? = nil,
+        onItemTap: ((Item) -> Void)? = nil
+    ) {
+        self.items = items
+        self.columns = columns
+        self.spacing = spacing
+        self._selectedIDs = selectedIDs
+        self.content = content
+        self.onItemAppear = onItemAppear
+        self.onItemTap = onItemTap
+    }
+    
+    // MARK: - UIViewRepresentable
+    
+    public func makeUIView(context: Context) -> UICollectionView {
+        let layout = UICollectionViewFlowLayout()
+        layout.minimumInteritemSpacing = spacing
+        layout.minimumLineSpacing = spacing
+        
+        let collectionView = SelectableCollectionView<Item>(frame: .zero, collectionViewLayout: layout)
+        collectionView.columns = columns
+        collectionView.backgroundColor = .systemBackground
+        collectionView.delegate = context.coordinator
+        collectionView.dataSource = context.coordinator
+        
+        // セルの登録
+        collectionView.register(
+            HostingCollectionViewCell<Content>.self,
+            forCellWithReuseIdentifier: "Cell"
+        )
+        
+        context.coordinator.setupGestureRecognizers(for: collectionView)
+        
+        return collectionView
+    }
+    
+    public func updateUIView(_ uiView: UICollectionView, context: Context) {
+        guard let collectionView = uiView as? SelectableCollectionView<Item> else { return }
+        
+        context.coordinator.items = items
+        context.coordinator.selectedIDs = selectedIDs
+        collectionView.columns = columns
+        
+        // データの更新
+        collectionView.reloadData()
+        
+        // レイアウトの更新
+        if let layout = collectionView.collectionViewLayout as? UICollectionViewFlowLayout {
+            layout.minimumInteritemSpacing = spacing
+            layout.minimumLineSpacing = spacing
+        }
+    }
+    
+    public func makeCoordinator() -> Coordinator {
+        Coordinator(
+            items: items,
+            selectedIDs: selectedIDs,
+            content: content,
+            onItemAppear: onItemAppear,
+            onItemTap: onItemTap,
+            selectedIDsBinding: $selectedIDs
+        )
+    }
+}
+
+// MARK: - Coordinator
+
+extension GridView {
+    public class Coordinator: NSObject, UICollectionViewDataSource, UICollectionViewDelegate, UICollectionViewDelegateFlowLayout {
+        var items: [Item]
+        var selectedIDs: Set<Item.ID>?
+        let content: (Item, Bool) -> Content
+        let onItemAppear: ((Item) -> Void)?
+        let onItemTap: ((Item) -> Void)?
+        let selectedIDsBinding: Binding<Set<Item.ID>?>
+        
+        private var panGestureRecognizer: UIPanGestureRecognizer?
+        private var autoScrollTimer: CADisplayLink?
+        private var initialSelectionState: Bool = false
+        private var lastSelectedIndexPath: IndexPath?
+        
+        init(
+            items: [Item],
+            selectedIDs: Set<Item.ID>?,
+            content: @escaping (Item, Bool) -> Content,
+            onItemAppear: ((Item) -> Void)?,
+            onItemTap: ((Item) -> Void)?,
+            selectedIDsBinding: Binding<Set<Item.ID>?>
+        ) {
+            self.items = items
+            self.selectedIDs = selectedIDs
+            self.content = content
+            self.onItemAppear = onItemAppear
+            self.onItemTap = onItemTap
+            self.selectedIDsBinding = selectedIDsBinding
+        }
+        
+        // MARK: - Gesture Setup
+        
+        func setupGestureRecognizers(for collectionView: UICollectionView) {
+            // タップジェスチャー（既存のdidSelectItemAtで処理）
+            
+            // パンジェスチャー（スワイプ選択用）
+            let panGesture = UIPanGestureRecognizer(target: self, action: #selector(handlePanGesture(_:)))
+            panGesture.delegate = self
+            collectionView.addGestureRecognizer(panGesture)
+            self.panGestureRecognizer = panGesture
+        }
+        
+        // MARK: - UICollectionViewDataSource
+        
+        func numberOfSections(in collectionView: UICollectionView) -> Int {
+            return 1
+        }
+        
+        func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+            return items.count
+        }
+        
+        func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+            let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "Cell", for: indexPath) as! HostingCollectionViewCell<Content>
+            
+            let item = items[indexPath.item]
+            let isSelected = selectedIDs?.contains(item.id) ?? false
+            let contentView = content(item, isSelected)
+            
+            cell.configure(with: contentView)
+            
+            return cell
+        }
+        
+        // MARK: - UICollectionViewDelegate
+        
+        func collectionView(_ collectionView: UICollectionView, willDisplay cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
+            let item = items[indexPath.item]
+            onItemAppear?(item)
+        }
+        
+        func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+            // 選択モードでない場合はタップコールバックのみ
+            guard selectedIDs != nil else {
+                let item = items[indexPath.item]
+                onItemTap?(item)
+                return
+            }
+            
+            toggleSelection(at: indexPath, in: collectionView)
+        }
+        
+        // MARK: - UICollectionViewDelegateFlowLayout
+        
+        func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+            guard let layout = collectionViewLayout as? UICollectionViewFlowLayout else {
+                return CGSize(width: 100, height: 100)
+            }
+            
+            let columns = CGFloat((collectionView as? SelectableCollectionView<Item>)?.columns ?? 3)
+            let width = collectionView.bounds.width
+            let totalSpacing = layout.minimumInteritemSpacing * (columns - 1)
+            let itemWidth = (width - totalSpacing) / columns
+            
+            return CGSize(width: itemWidth, height: itemWidth)
+        }
+        
+        // MARK: - Selection Handling
+        
+        private func toggleSelection(at indexPath: IndexPath, in collectionView: UICollectionView) {
+            let item = items[indexPath.item]
+            
+            if selectedIDs?.contains(item.id) == true {
+                selectedIDs?.remove(item.id)
+            } else {
+                if selectedIDs == nil {
+                    selectedIDs = Set<Item.ID>()
+                }
+                selectedIDs?.insert(item.id)
+            }
+            
+            selectedIDsBinding.wrappedValue = selectedIDs
+            collectionView.reloadItems(at: [indexPath])
+            
+            // ハプティックフィードバック
+            let generator = UIImpactFeedbackGenerator(style: .light)
+            generator.impactOccurred()
+        }
+        
+        // MARK: - Pan Gesture Handling
+        
+        @objc private func handlePanGesture(_ gesture: UIPanGestureRecognizer) {
+            guard let collectionView = gesture.view as? UICollectionView,
+                  selectedIDs != nil else { return }
+            
+            let location = gesture.location(in: collectionView)
+            
+            switch gesture.state {
+            case .began:
+                handlePanBegan(at: location, in: collectionView)
+            case .changed:
+                handlePanChanged(at: location, in: collectionView)
+            case .ended, .cancelled:
+                handlePanEnded()
+            default:
+                break
+            }
+        }
+        
+        private func handlePanBegan(at location: CGPoint, in collectionView: UICollectionView) {
+            guard let indexPath = collectionView.indexPathForItem(at: location) else { return }
+            
+            let item = items[indexPath.item]
+            initialSelectionState = !(selectedIDs?.contains(item.id) ?? false)
+            lastSelectedIndexPath = indexPath
+            
+            // 最初のアイテムの選択状態を切り替え
+            toggleSelection(at: indexPath, in: collectionView)
+            
+            // 自動スクロールの開始
+            startAutoScrollIfNeeded(in: collectionView)
+        }
+        
+        private func handlePanChanged(at location: CGPoint, in collectionView: UICollectionView) {
+            guard let indexPath = collectionView.indexPathForItem(at: location),
+                  indexPath != lastSelectedIndexPath else { return }
+            
+            let item = items[indexPath.item]
+            let isCurrentlySelected = selectedIDs?.contains(item.id) ?? false
+            
+            // 初期状態と異なる場合のみ切り替え
+            if isCurrentlySelected != initialSelectionState {
+                toggleSelection(at: indexPath, in: collectionView)
+            }
+            
+            lastSelectedIndexPath = indexPath
+        }
+        
+        private func handlePanEnded() {
+            stopAutoScroll()
+            lastSelectedIndexPath = nil
+        }
+        
+        // MARK: - Auto Scroll
+        
+        private func startAutoScrollIfNeeded(in collectionView: UICollectionView) {
+            autoScrollTimer = CADisplayLink(target: self, selector: #selector(autoScroll))
+            autoScrollTimer?.add(to: .current, forMode: .common)
+        }
+        
+        private func stopAutoScroll() {
+            autoScrollTimer?.invalidate()
+            autoScrollTimer = nil
+        }
+        
+        @objc private func autoScroll() {
+            guard let collectionView = panGestureRecognizer?.view as? UICollectionView else { return }
+            
+            let location = panGestureRecognizer?.location(in: collectionView) ?? .zero
+            let bounds = collectionView.bounds
+            let scrollZoneHeight: CGFloat = 50
+            
+            var scrollVelocity: CGFloat = 0
+            
+            if location.y < scrollZoneHeight {
+                // 上端近く - 上にスクロール
+                let progress = (scrollZoneHeight - location.y) / scrollZoneHeight
+                scrollVelocity = -progress * 10
+            } else if location.y > bounds.height - scrollZoneHeight {
+                // 下端近く - 下にスクロール
+                let progress = (location.y - (bounds.height - scrollZoneHeight)) / scrollZoneHeight
+                scrollVelocity = progress * 10
+            }
+            
+            if scrollVelocity != 0 {
+                let newOffset = CGPoint(
+                    x: collectionView.contentOffset.x,
+                    y: collectionView.contentOffset.y + scrollVelocity
+                )
+                collectionView.setContentOffset(newOffset, animated: false)
+                
+                // スクロール中の選択処理
+                if let location = panGestureRecognizer?.location(in: collectionView) {
+                    handlePanChanged(at: location, in: collectionView)
+                }
+            }
+        }
+    }
+}
+
+// MARK: - UIGestureRecognizerDelegate
+
+extension GridView.Coordinator: UIGestureRecognizerDelegate {
+    public func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
+        // スクロールビューのジェスチャーと同時に認識
+        return true
+    }
+}
+
+// MARK: - SelectableCollectionView
+
+private class SelectableCollectionView<Item: Identifiable>: UICollectionView {
+    var columns: Int = 3
+}
+
+// MARK: - HostingCollectionViewCell
+
+private class HostingCollectionViewCell<Content: View>: UICollectionViewCell {
+    private var hostingController: UIHostingController<Content>?
+    
+    func configure(with content: Content) {
+        if let hostingController = hostingController {
+            hostingController.rootView = content
+        } else {
+            let hostingController = UIHostingController(rootView: content)
+            hostingController.view.backgroundColor = .clear
+            self.hostingController = hostingController
+            
+            contentView.addSubview(hostingController.view)
+            hostingController.view.translatesAutoresizingMaskIntoConstraints = false
+            NSLayoutConstraint.activate([
+                hostingController.view.topAnchor.constraint(equalTo: contentView.topAnchor),
+                hostingController.view.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+                hostingController.view.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+                hostingController.view.bottomAnchor.constraint(equalTo: contentView.bottomAnchor)
+            ])
+        }
+    }
+    
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        // HostingControllerをリセット
+        hostingController?.view.removeFromSuperview()
+        hostingController = nil
+    }
+}

--- a/MediaLibrary/Sources/Presentation/Views/MediaLibraryView+Preview.swift
+++ b/MediaLibrary/Sources/Presentation/Views/MediaLibraryView+Preview.swift
@@ -67,9 +67,12 @@ private func createSampleThumbnails() -> [Media.ID: Media.Thumbnail] {
         error: nil,
         hasError: false,
         thumbnails: [:],
+        isSelectionMode: false,
+        selectedMediaIDs: .constant(nil),
         onLoadPhotos: {},
         onLoadThumbnail: { _, _ in },
-        onClearError: {}
+        onClearError: {},
+        onToggleSelectionMode: {}
     )
 }
 
@@ -80,9 +83,12 @@ private func createSampleThumbnails() -> [Media.ID: Media.Thumbnail] {
         error: nil,
         hasError: false,
         thumbnails: [:],
+        isSelectionMode: false,
+        selectedMediaIDs: .constant(nil),
         onLoadPhotos: {},
         onLoadThumbnail: { _, _ in },
-        onClearError: {}
+        onClearError: {},
+        onToggleSelectionMode: {}
     )
 }
 
@@ -93,9 +99,12 @@ private func createSampleThumbnails() -> [Media.ID: Media.Thumbnail] {
         error: nil,
         hasError: false,
         thumbnails: createSampleThumbnails(),
+        isSelectionMode: false,
+        selectedMediaIDs: .constant(nil),
         onLoadPhotos: {},
         onLoadThumbnail: { _, _ in },
-        onClearError: {}
+        onClearError: {},
+        onToggleSelectionMode: {}
     )
 }
 
@@ -106,9 +115,12 @@ private func createSampleThumbnails() -> [Media.ID: Media.Thumbnail] {
         error: .permissionDenied,
         hasError: true,
         thumbnails: [:],
+        isSelectionMode: false,
+        selectedMediaIDs: .constant(nil),
         onLoadPhotos: {},
         onLoadThumbnail: { _, _ in },
-        onClearError: {}
+        onClearError: {},
+        onToggleSelectionMode: {}
     )
 }
 
@@ -119,9 +131,12 @@ private func createSampleThumbnails() -> [Media.ID: Media.Thumbnail] {
         error: .mediaLoadFailed,
         hasError: true,
         thumbnails: [:],
+        isSelectionMode: false,
+        selectedMediaIDs: .constant(nil),
         onLoadPhotos: {},
         onLoadThumbnail: { _, _ in },
-        onClearError: {}
+        onClearError: {},
+        onToggleSelectionMode: {}
     )
 }
 
@@ -132,9 +147,12 @@ private func createSampleThumbnails() -> [Media.ID: Media.Thumbnail] {
         error: nil,
         hasError: false,
         thumbnails: createSampleThumbnails(),
+        isSelectionMode: false,
+        selectedMediaIDs: .constant(nil),
         onLoadPhotos: {},
         onLoadThumbnail: { _, _ in },
-        onClearError: {}
+        onClearError: {},
+        onToggleSelectionMode: {}
     )
 }
 


### PR DESCRIPTION
## Summary
- 汎用的なGridView（UICollectionView wrapper）を作成し、写真の複数選択機能を実装
- タップ選択、スワイプ選択、画面端での自動スクロール機能を含む完全な選択システム
- MediaLibraryViewに選択モード切り替えボタンを追加し、選択状態の視覚的フィードバックを提供

## 実装内容
- **GridView.swift**: UICollectionViewをSwiftUIで使用するための汎用ラッパー
- **選択機能**: タップ選択、スワイプ選択、自動スクロール
- **UI更新**: MediaLibraryViewでGridViewを使用、選択モード切り替えボタン追加
- **状態管理**: MediaLibraryViewModelで選択状態を管理
- **ローカライゼーション**: 「選択」「完了」ボタンの多言語対応

## Test plan
- [ ] iOS実機/シミュレーターでの動作確認
- [ ] 基本的なタップ選択機能の動作確認
- [ ] スワイプ選択機能の動作確認
- [ ] 画面端での自動スクロール機能の動作確認
- [ ] 選択モード切り替えの動作確認
- [ ] 大量の写真での性能確認

🤖 Generated with [Claude Code](https://claude.ai/code)